### PR TITLE
 localiza mensajes de excepción (es/en/fr)

### DIFF
--- a/ClassLibraryGuessWho/Properties/Localization/Common.Designer.cs
+++ b/ClassLibraryGuessWho/Properties/Localization/Common.Designer.cs
@@ -88,6 +88,60 @@ namespace ClassLibraryGuessWho.Properties.Localization {
         }
         
         /// <summary>
+        ///   Busca una cadena traducida similar a Unable to connect to the database.
+        /// </summary>
+        public static string FaultDatabaseConnection {
+            get {
+                return ResourceManager.GetString("FaultDatabaseConnection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a The database server took too long to respond.
+        /// </summary>
+        public static string FaultDatabaseTimeout {
+            get {
+                return ResourceManager.GetString("FaultDatabaseTimeout", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a The email address is already registered.
+        /// </summary>
+        public static string FaultDuplicateEmail {
+            get {
+                return ResourceManager.GetString("FaultDuplicateEmail", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a The operation violates an existing relationship.
+        /// </summary>
+        public static string FaultForeignKey {
+            get {
+                return ResourceManager.GetString("FaultForeignKey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a The request is invalid.
+        /// </summary>
+        public static string FaultInvalidRequest {
+            get {
+                return ResourceManager.GetString("FaultInvalidRequest", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a An unexpected error occurred.
+        /// </summary>
+        public static string FaultUnexpected {
+            get {
+                return ResourceManager.GetString("FaultUnexpected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Busca una cadena traducida similar a Confirm Password.
         /// </summary>
         public static string LblConfirmPassword {
@@ -138,6 +192,123 @@ namespace ClassLibraryGuessWho.Properties.Localization {
         public static string LinkForgot {
             get {
                 return ResourceManager.GetString("LinkForgot", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a Account created.
+        /// </summary>
+        public static string UiAccountCreatedForFmt {
+            get {
+                return ResourceManager.GetString("UiAccountCreatedForFmt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a Could not communicate with the service.
+        /// </summary>
+        public static string UiCommsGeneric {
+            get {
+                return ResourceManager.GetString("UiCommsGeneric", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a Transport authentication (Windows) failed. Verify that the service is running.
+        /// </summary>
+        public static string UiSecurityNegotiationFailed {
+            get {
+                return ResourceManager.GetString("UiSecurityNegotiationFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a Error.
+        /// </summary>
+        public static string UiTitleError {
+            get {
+                return ResourceManager.GetString("UiTitleError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a Information.
+        /// </summary>
+        public static string UiTitleInfo {
+            get {
+                return ResourceManager.GetString("UiTitleInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a Warning.
+        /// </summary>
+        public static string UiTitleWarning {
+            get {
+                return ResourceManager.GetString("UiTitleWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a Display name is required.
+        /// </summary>
+        public static string UiValidationDisplayNameRequired {
+            get {
+                return ResourceManager.GetString("UiValidationDisplayNameRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a Display name is too long (max. 50 characteres).
+        /// </summary>
+        public static string UiValidationDisplayNameTooLong {
+            get {
+                return ResourceManager.GetString("UiValidationDisplayNameTooLong", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a Invalid email format.
+        /// </summary>
+        public static string UiValidationEmailFormat {
+            get {
+                return ResourceManager.GetString("UiValidationEmailFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a Email is required.
+        /// </summary>
+        public static string UiValidationEmailRequired {
+            get {
+                return ResourceManager.GetString("UiValidationEmailRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a Passwords do not match.
+        /// </summary>
+        public static string UiValidationPasswordDontMatch {
+            get {
+                return ResourceManager.GetString("UiValidationPasswordDontMatch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a Password is required.
+        /// </summary>
+        public static string UiValidationPasswordRequired {
+            get {
+                return ResourceManager.GetString("UiValidationPasswordRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a Password must be at least 8 characters long.
+        /// </summary>
+        public static string UiValidationPasswordTooShort {
+            get {
+                return ResourceManager.GetString("UiValidationPasswordTooShort", resourceCulture);
             }
         }
     }

--- a/ClassLibraryGuessWho/Properties/Localization/Common.es-MX.resx
+++ b/ClassLibraryGuessWho/Properties/Localization/Common.es-MX.resx
@@ -126,6 +126,24 @@
   <data name="BtnLogin" xml:space="preserve">
     <value>Entrar</value>
   </data>
+  <data name="FaultDatabaseConnection" xml:space="preserve">
+    <value>No se pudo conectar con la base de datos</value>
+  </data>
+  <data name="FaultDatabaseTimeout" xml:space="preserve">
+    <value>El servidor de base de datos tardó demasiado en responder</value>
+  </data>
+  <data name="FaultDuplicateEmail" xml:space="preserve">
+    <value>El correo ya está registrado</value>
+  </data>
+  <data name="FaultForeignKey" xml:space="preserve">
+    <value>La operación viola una relación existente</value>
+  </data>
+  <data name="FaultInvalidRequest" xml:space="preserve">
+    <value>La solicitud es inválida</value>
+  </data>
+  <data name="FaultUnexpected" xml:space="preserve">
+    <value>Ocurrió un error inesperado</value>
+  </data>
   <data name="LblConfirmPassword" xml:space="preserve">
     <value>Confirmar contraseña</value>
   </data>
@@ -143,5 +161,44 @@
   </data>
   <data name="LinkForgot" xml:space="preserve">
     <value>Olvidé mi contraseña</value>
+  </data>
+  <data name="UiAccountCreatedForFmt" xml:space="preserve">
+    <value>Cuenta creada</value>
+  </data>
+  <data name="UiCommsGeneric" xml:space="preserve">
+    <value>No se pudo comunicar con el servicio</value>
+  </data>
+  <data name="UiSecurityNegotiationFailed" xml:space="preserve">
+    <value>Falló la autenticación del transporte (Windows). Verifica que el servicio esté en ejecución</value>
+  </data>
+  <data name="UiTitleError" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="UiTitleInfo" xml:space="preserve">
+    <value>Información</value>
+  </data>
+  <data name="UiTitleWarning" xml:space="preserve">
+    <value>Advertencia </value>
+  </data>
+  <data name="UiValidationDisplayNameRequired" xml:space="preserve">
+    <value>El nombre es requerido</value>
+  </data>
+  <data name="UiValidationDisplayNameTooLong" xml:space="preserve">
+    <value>El nombre visible es demasiado largo (máx. 50 caracteres)</value>
+  </data>
+  <data name="UiValidationEmailFormat" xml:space="preserve">
+    <value>El formato de correo no es válido</value>
+  </data>
+  <data name="UiValidationEmailRequired" xml:space="preserve">
+    <value>El correo es requerido</value>
+  </data>
+  <data name="UiValidationPasswordDontMatch" xml:space="preserve">
+    <value>Las contraseñas no coinciden</value>
+  </data>
+  <data name="UiValidationPasswordRequired" xml:space="preserve">
+    <value>La contraseña es requerida</value>
+  </data>
+  <data name="UiValidationPasswordTooShort" xml:space="preserve">
+    <value>La contraseña debe tener al menos 8 caracteres</value>
   </data>
 </root>

--- a/ClassLibraryGuessWho/Properties/Localization/Common.fr-FR.resx
+++ b/ClassLibraryGuessWho/Properties/Localization/Common.fr-FR.resx
@@ -126,6 +126,24 @@
   <data name="BtnLogin" xml:space="preserve">
     <value>Connexion</value>
   </data>
+  <data name="FaultDatabaseConnection" xml:space="preserve">
+    <value>Impossible de se connecter à la base de données</value>
+  </data>
+  <data name="FaultDatabaseTimeout" xml:space="preserve">
+    <value>Le serveur de base de données a mis trop de temps à répondre</value>
+  </data>
+  <data name="FaultDuplicateEmail" xml:space="preserve">
+    <value>L’adresse e-mail est déjà enregistrée</value>
+  </data>
+  <data name="FaultForeignKey" xml:space="preserve">
+    <value>L’opération viole une relation existante</value>
+  </data>
+  <data name="FaultInvalidRequest" xml:space="preserve">
+    <value>La requête est invalide</value>
+  </data>
+  <data name="FaultUnexpected" xml:space="preserve">
+    <value>Une erreur inattendue s’est produite</value>
+  </data>
   <data name="LblConfirmPassword" xml:space="preserve">
     <value>Confirmer le mot de passe</value>
   </data>
@@ -143,5 +161,44 @@
   </data>
   <data name="LinkForgot" xml:space="preserve">
     <value>J’ai oublié mon mot de passe</value>
+  </data>
+  <data name="UiAccountCreatedForFmt" xml:space="preserve">
+    <value>Compte créé</value>
+  </data>
+  <data name="UiCommsGeneric" xml:space="preserve">
+    <value>Impossible de communiquer avec le service</value>
+  </data>
+  <data name="UiSecurityNegotiationFailed" xml:space="preserve">
+    <value>L’authentification du transport (Windows) a échoué. Vérifiez que le service est en cours d’exécution</value>
+  </data>
+  <data name="UiTitleError" xml:space="preserve">
+    <value>Erreur</value>
+  </data>
+  <data name="UiTitleInfo" xml:space="preserve">
+    <value>Information</value>
+  </data>
+  <data name="UiTitleWarning" xml:space="preserve">
+    <value>Avertissement</value>
+  </data>
+  <data name="UiValidationDisplayNameRequired" xml:space="preserve">
+    <value>Le nom d’affichage est requis</value>
+  </data>
+  <data name="UiValidationDisplayNameTooLong" xml:space="preserve">
+    <value>Le nom d’affichage est trop long (max. 50 caractères)</value>
+  </data>
+  <data name="UiValidationEmailFormat" xml:space="preserve">
+    <value>Format d’e-mail invalide</value>
+  </data>
+  <data name="UiValidationEmailRequired" xml:space="preserve">
+    <value>L’adresse e-mail est requise</value>
+  </data>
+  <data name="UiValidationPasswordDontMatch" xml:space="preserve">
+    <value>Les mots de passe ne correspondent pas</value>
+  </data>
+  <data name="UiValidationPasswordRequired" xml:space="preserve">
+    <value>Le mot de passe est requis</value>
+  </data>
+  <data name="UiValidationPasswordTooShort" xml:space="preserve">
+    <value>Le mot de passe doit comporter au moins 8 caractères</value>
   </data>
 </root>

--- a/ClassLibraryGuessWho/Properties/Localization/Common.resx
+++ b/ClassLibraryGuessWho/Properties/Localization/Common.resx
@@ -126,6 +126,24 @@
   <data name="BtnLogin" xml:space="preserve">
     <value>Login</value>
   </data>
+  <data name="FaultDatabaseConnection" xml:space="preserve">
+    <value>Unable to connect to the database</value>
+  </data>
+  <data name="FaultDatabaseTimeout" xml:space="preserve">
+    <value>The database server took too long to respond</value>
+  </data>
+  <data name="FaultDuplicateEmail" xml:space="preserve">
+    <value>The email address is already registered</value>
+  </data>
+  <data name="FaultForeignKey" xml:space="preserve">
+    <value>The operation violates an existing relationship</value>
+  </data>
+  <data name="FaultInvalidRequest" xml:space="preserve">
+    <value>The request is invalid</value>
+  </data>
+  <data name="FaultUnexpected" xml:space="preserve">
+    <value>An unexpected error occurred</value>
+  </data>
   <data name="LblConfirmPassword" xml:space="preserve">
     <value>Confirm Password</value>
   </data>
@@ -143,5 +161,44 @@
   </data>
   <data name="LinkForgot" xml:space="preserve">
     <value>I forgot my password</value>
+  </data>
+  <data name="UiAccountCreatedForFmt" xml:space="preserve">
+    <value>Account created</value>
+  </data>
+  <data name="UiCommsGeneric" xml:space="preserve">
+    <value>Could not communicate with the service</value>
+  </data>
+  <data name="UiSecurityNegotiationFailed" xml:space="preserve">
+    <value>Transport authentication (Windows) failed. Verify that the service is running</value>
+  </data>
+  <data name="UiTitleError" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="UiTitleInfo" xml:space="preserve">
+    <value>Information</value>
+  </data>
+  <data name="UiTitleWarning" xml:space="preserve">
+    <value>Warning</value>
+  </data>
+  <data name="UiValidationDisplayNameRequired" xml:space="preserve">
+    <value>Display name is required</value>
+  </data>
+  <data name="UiValidationDisplayNameTooLong" xml:space="preserve">
+    <value>Display name is too long (max. 50 characteres)</value>
+  </data>
+  <data name="UiValidationEmailFormat" xml:space="preserve">
+    <value>Invalid email format</value>
+  </data>
+  <data name="UiValidationEmailRequired" xml:space="preserve">
+    <value>Email is required</value>
+  </data>
+  <data name="UiValidationPasswordDontMatch" xml:space="preserve">
+    <value>Passwords do not match</value>
+  </data>
+  <data name="UiValidationPasswordRequired" xml:space="preserve">
+    <value>Password is required</value>
+  </data>
+  <data name="UiValidationPasswordTooShort" xml:space="preserve">
+    <value>Password must be at least 8 characters long</value>
   </data>
 </root>

--- a/GuessWhoClient/App.config
+++ b/GuessWhoClient/App.config
@@ -2,11 +2,11 @@
 <configuration>
 	<configSections>
 		<sectionGroup name="userSettings"
-					  type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+       type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
 			<section name="WPFGuessWhoClient.Properties.Settings"
-					 type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-					 allowExeDefinition="MachineToLocalUser"
-					 requirePermission="false" />
+      type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+      allowExeDefinition="MachineToLocalUser"
+      requirePermission="false" />
 		</sectionGroup>
 	</configSections>
 
@@ -16,23 +16,16 @@
 
 	<system.serviceModel>
 		<bindings>
-			<netTcpBinding>
-				<binding name="NetTcp_Windows_Client" maxReceivedMessageSize="65536">
-					<security mode="Transport">
-						<transport clientCredentialType="Windows" />
-					</security>
-				</binding>
-			</netTcpBinding>
-		</bindings>
+   <netTcpBinding>
+    <binding name="NetTcp_Windows_Client" maxReceivedMessageSize="65536" />
+   </netTcpBinding>
+  </bindings>
 
 		<client>
-			<endpoint
-			  name="NetTcp_UserService"
-			  address="net.tcp://localhost:8095/UserService"
-			  binding="netTcpBinding"
-			  bindingConfiguration="NetTcp_Windows_Client"
-			  contract="UserServiceRef.IUserService" />
-		</client>
+   <endpoint address="net.tcp://localhost:8095/UserService" binding="netTcpBinding"
+    bindingConfiguration="NetTcp_Windows_Client" contract="UserServiceRef.IUserService"
+    name="NetTcp_UserService" />
+  </client>
 	</system.serviceModel>
 
 	<userSettings>

--- a/GuessWhoClient/App.xaml
+++ b/GuessWhoClient/App.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:GuessWhoClient"
-             StartupUri="LoginWindow.xaml">
+             StartupUri="MainMenuWindow.xaml">
     
     <Application.Resources>
         <ResourceDictionary>

--- a/GuessWhoClient/Connected Services/UserServiceRef/Reference.cs
+++ b/GuessWhoClient/Connected Services/UserServiceRef/Reference.cs
@@ -196,11 +196,89 @@ namespace GuessWhoClient.UserServiceRef {
         }
     }
     
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Runtime.Serialization", "4.0.0.0")]
+    [System.Runtime.Serialization.DataContractAttribute(Name="ServiceFault", Namespace="http://schemas.datacontract.org/2004/07/")]
+    [System.SerializableAttribute()]
+    public partial class ServiceFault : object, System.Runtime.Serialization.IExtensibleDataObject, System.ComponentModel.INotifyPropertyChanged {
+        
+        [System.NonSerializedAttribute()]
+        private System.Runtime.Serialization.ExtensionDataObject extensionDataField;
+        
+        [System.Runtime.Serialization.OptionalFieldAttribute()]
+        private string CodeField;
+        
+        [System.Runtime.Serialization.OptionalFieldAttribute()]
+        private string MessageField;
+        
+        [System.Runtime.Serialization.OptionalFieldAttribute()]
+        private string CorrelationIdField;
+        
+        [global::System.ComponentModel.BrowsableAttribute(false)]
+        public System.Runtime.Serialization.ExtensionDataObject ExtensionData {
+            get {
+                return this.extensionDataField;
+            }
+            set {
+                this.extensionDataField = value;
+            }
+        }
+        
+        [System.Runtime.Serialization.DataMemberAttribute()]
+        public string Code {
+            get {
+                return this.CodeField;
+            }
+            set {
+                if ((object.ReferenceEquals(this.CodeField, value) != true)) {
+                    this.CodeField = value;
+                    this.RaisePropertyChanged("Code");
+                }
+            }
+        }
+        
+        [System.Runtime.Serialization.DataMemberAttribute()]
+        public string Message {
+            get {
+                return this.MessageField;
+            }
+            set {
+                if ((object.ReferenceEquals(this.MessageField, value) != true)) {
+                    this.MessageField = value;
+                    this.RaisePropertyChanged("Message");
+                }
+            }
+        }
+        
+        [System.Runtime.Serialization.DataMemberAttribute(Order=2)]
+        public string CorrelationId {
+            get {
+                return this.CorrelationIdField;
+            }
+            set {
+                if ((object.ReferenceEquals(this.CorrelationIdField, value) != true)) {
+                    this.CorrelationIdField = value;
+                    this.RaisePropertyChanged("CorrelationId");
+                }
+            }
+        }
+        
+        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        
+        protected void RaisePropertyChanged(string propertyName) {
+            System.ComponentModel.PropertyChangedEventHandler propertyChanged = this.PropertyChanged;
+            if ((propertyChanged != null)) {
+                propertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+            }
+        }
+    }
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.ServiceModel", "4.0.0.0")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="UserServiceRef.IUserService")]
     public interface IUserService {
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IUserService/RegisterUser", ReplyAction="http://tempuri.org/IUserService/RegisterUserResponse")]
+        [System.ServiceModel.FaultContractAttribute(typeof(GuessWhoClient.UserServiceRef.ServiceFault), Action="http://tempuri.org/IUserService/RegisterUserServiceFaultFault", Name="ServiceFault", Namespace="http://schemas.datacontract.org/2004/07/")]
         GuessWhoClient.UserServiceRef.RegisterResponse RegisterUser(GuessWhoClient.UserServiceRef.RegisterRequest request);
         
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IUserService/RegisterUser", ReplyAction="http://tempuri.org/IUserService/RegisterUserResponse")]

--- a/GuessWhoClient/Connected Services/UserServiceRef/Reference.svcmap
+++ b/GuessWhoClient/Connected Services/UserServiceRef/Reference.svcmap
@@ -26,6 +26,7 @@
     <MetadataFile FileName="service.xsd" MetadataType="Schema" ID="99077632-9efb-482d-aeb5-502c167bef17" SourceId="1" SourceUrl="net.tcp://localhost:8095/UserService/mex" />
     <MetadataFile FileName="service1.xsd" MetadataType="Schema" ID="ad2a8c84-3c56-45c8-85c3-083dad9153ed" SourceId="1" SourceUrl="net.tcp://localhost:8095/UserService/mex" />
     <MetadataFile FileName="GuessWho.Contracts.Dtos.xsd" MetadataType="Schema" ID="db7d8523-2b44-4045-923f-f7ef85488f6c" SourceId="1" SourceUrl="net.tcp://localhost:8095/UserService/mex" />
+    <MetadataFile FileName="service2.xsd" MetadataType="Schema" ID="b1542fac-3075-4abe-b183-dcc6e0e427a7" SourceId="1" SourceUrl="net.tcp://localhost:8095/UserService/mex" />
   </Metadata>
   <Extensions>
     <ExtensionFile FileName="configuration91.svcinfo" Name="configuration91.svcinfo" />

--- a/GuessWhoClient/Connected Services/UserServiceRef/service.wsdl
+++ b/GuessWhoClient/Connected Services/UserServiceRef/service.wsdl
@@ -36,6 +36,7 @@
   <wsdl:types>
     <xsd:schema targetNamespace="http://tempuri.org/Imports">
       <xsd:import namespace="http://tempuri.org/" />
+      <xsd:import namespace="http://schemas.datacontract.org/2004/07/" />
       <xsd:import namespace="http://schemas.microsoft.com/2003/10/Serialization/" />
       <xsd:import namespace="http://schemas.datacontract.org/2004/07/GuessWho.Contracts.Dtos" />
     </xsd:schema>
@@ -46,10 +47,14 @@
   <wsdl:message name="IUserService_RegisterUser_OutputMessage">
     <wsdl:part name="parameters" element="tns:RegisterUserResponse" />
   </wsdl:message>
+  <wsdl:message name="IUserService_RegisterUser_ServiceFaultFault_FaultMessage">
+    <wsdl:part xmlns:q1="http://schemas.datacontract.org/2004/07/" name="detail" element="q1:ServiceFault" />
+  </wsdl:message>
   <wsdl:portType name="IUserService">
     <wsdl:operation name="RegisterUser">
       <wsdl:input wsaw:Action="http://tempuri.org/IUserService/RegisterUser" message="tns:IUserService_RegisterUser_InputMessage" />
       <wsdl:output wsaw:Action="http://tempuri.org/IUserService/RegisterUserResponse" message="tns:IUserService_RegisterUser_OutputMessage" />
+      <wsdl:fault wsaw:Action="http://tempuri.org/IUserService/RegisterUserServiceFaultFault" name="ServiceFaultFault" message="tns:IUserService_RegisterUser_ServiceFaultFault_FaultMessage" />
     </wsdl:operation>
   </wsdl:portType>
   <wsdl:binding name="NetTcpBinding_IUserService" type="tns:IUserService">
@@ -64,6 +69,9 @@
       <wsdl:output>
         <soap12:body use="literal" />
       </wsdl:output>
+      <wsdl:fault name="ServiceFaultFault">
+        <soap12:fault use="literal" name="ServiceFaultFault" namespace="" />
+      </wsdl:fault>
     </wsdl:operation>
   </wsdl:binding>
   <wsdl:service name="UserService">

--- a/GuessWhoClient/Connected Services/UserServiceRef/service2.xsd
+++ b/GuessWhoClient/Connected Services/UserServiceRef/service2.xsd
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:tns="http://schemas.datacontract.org/2004/07/" elementFormDefault="qualified" targetNamespace="http://schemas.datacontract.org/2004/07/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="ServiceFault">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="Code" nillable="true" type="xs:string" />
+      <xs:element minOccurs="0" name="Message" nillable="true" type="xs:string" />
+      <xs:element minOccurs="0" name="CorrelationId" nillable="true" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="ServiceFault" nillable="true" type="tns:ServiceFault" />
+</xs:schema>

--- a/GuessWhoClient/CreateAccountWindow.xaml
+++ b/GuessWhoClient/CreateAccountWindow.xaml
@@ -77,6 +77,6 @@
                 Content="{Binding [BtnCreateAccount], Source={x:Static localization:LocalizationProvider.Instance}}"
                 Style="{StaticResource Btn.Primary}" Height="48" Width="200"
                 HorizontalAlignment="Center"
-                Click="btnCreateAccount_Click"/>
+                Click="BtnCreateAccount_Click"/>
     </Grid>
 </Window>

--- a/GuessWhoClient/MainMenuWindow.xaml
+++ b/GuessWhoClient/MainMenuWindow.xaml
@@ -68,13 +68,14 @@
                             Style="{StaticResource Btn.Primary}"
                             Width="300" Height="80"
                             Margin="0,0,0,15"
-                            Click="btnProfile_Click"/>
+                            Click="BtnProfile_Click"/>
 
                     <Button x:Name="btnExit"
                             Content="Exit"
                             Style="{StaticResource Btn.Primary}"
                             Width="300" Height="80"
-                            Margin="0,0,0,0"/>
+                            Margin="0,0,0,0"
+                            Click="BtnExit_Click"/>
 
                 </StackPanel>
 

--- a/GuessWhoClient/MainMenuWindow.xaml.cs
+++ b/GuessWhoClient/MainMenuWindow.xaml.cs
@@ -9,7 +9,7 @@ namespace GuessWhoClient
             InitializeComponent();
         }
 
-        private void btnProfile_Click(object sender, RoutedEventArgs e)
+        private void BtnProfile_Click(object sender, RoutedEventArgs e)
         {
             var login = new LoginWindow
             {
@@ -26,5 +26,11 @@ namespace GuessWhoClient
 
             login.Show();
         }
+
+        private void BtnExit_Click(object sender, RoutedEventArgs e)
+        {
+            Application.Current.Shutdown();
+        }
     }
+
 }

--- a/GuessWhoClient/WPFGuessWhoClient.csproj
+++ b/GuessWhoClient/WPFGuessWhoClient.csproj
@@ -139,6 +139,9 @@
     <None Include="Connected Services\UserServiceRef\service1.xsd">
       <SubType>Designer</SubType>
     </None>
+    <None Include="Connected Services\UserServiceRef\service2.xsd">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>


### PR DESCRIPTION
Localize exception messages (es/en)

- Centralize exception texts in resource files (.resx).
- Replace hard-coded strings with resource keys across Faults and ServiceFault throws.
- Keep error codes/keys; only the displayed text changes.
- Add resource keys for common errors (e.g., InvalidRequest, UserNotFound, EmailAlreadyExists).
- No changes to contracts or business logic.